### PR TITLE
Add snoozing of metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 cache:
 rvm:
 - 2.3.0
-bundler_args: "--without development --path vendor/bundle"
+bundler_args: "--path vendor/bundle"
 script:
 - bundle exec rspec spec
 env:

--- a/app/assets/javascripts/broken_window/application.js
+++ b/app/assets/javascripts/broken_window/application.js
@@ -10,4 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/app/assets/stylesheets/broken_window/application.scss
+++ b/app/assets/stylesheets/broken_window/application.scss
@@ -21,5 +21,7 @@
   }
 }
 
+$snooze-color: green;
+
 @import "./*.sass"
 

--- a/app/assets/stylesheets/broken_window/layout.sass
+++ b/app/assets/stylesheets/broken_window/layout.sass
@@ -8,6 +8,7 @@ a.back-link
   text-align: center
 
   a
+    margin: 0 10px
     color: black
     font-size: 42px
     text-decoration: none
@@ -28,6 +29,9 @@ body
   &.unknown
     background-color: gray
 
+  &.snoozed
+    background-color: $snooze-color
+
   &.background-metric
     &.fail
       background-color: darken(red, 10%)
@@ -37,3 +41,6 @@ body
 
     &.unknown
       background-color: darken(gray, 10%)
+
+    &.snoozed
+      background-color: darken($snooze-color, 10%)

--- a/app/assets/stylesheets/broken_window/metrics_list.sass
+++ b/app/assets/stylesheets/broken_window/metrics_list.sass
@@ -8,6 +8,9 @@
   &.unknown
     background-color: grey
 
+  &.snoozed
+    background-color: $snooze-color
+
 .metrics-list
   margin: 50px
 

--- a/app/controllers/broken_window/metrics_controller.rb
+++ b/app/controllers/broken_window/metrics_controller.rb
@@ -39,6 +39,20 @@ module BrokenWindow
       end
     end
 
+    def snooze
+      @metric = Metric.find(params[:id])
+      @metric.snooze!
+
+      redirect_to @metric
+    end
+
+    def unsnooze
+      @metric = Metric.find(params[:id])
+      @metric.unsnooze!
+
+      redirect_to @metric
+    end
+
     private
 
     def metric_params

--- a/app/models/broken_window/measured_metric.rb
+++ b/app/models/broken_window/measured_metric.rb
@@ -38,12 +38,14 @@ module BrokenWindow
       metric
     end
 
-    delegate :name, :to_param, :threshold, :value_type, :threshold_type, :parent, :container?, to: :metric
+    delegate :name, :to_param, :threshold, :value_type, :threshold_type, :parent, :container?, :snoozed?, to: :metric
     delegate :value, to: :measurement, allow_nil: true
 
     private
 
     def calculate_status
+      return MetricStatus.snoozed if snoozed?
+
       if container?
         MetricStatus.combine(children.map(&:status))
       else

--- a/app/models/broken_window/metric.rb
+++ b/app/models/broken_window/metric.rb
@@ -4,6 +4,8 @@ module BrokenWindow
     THRESHOLD_TYPES = %w(min max)
     VALID_CLASS_NAME = /\A[A-Z][a-zA-Z_0-9\:]*\z/
 
+    SNOOZE_INTERVAL = 2.weeks
+
     has_many :measurements
 
     validates :name, presence: true, length: {maximum: 255}
@@ -36,5 +38,16 @@ module BrokenWindow
       calculator.blank?
     end
 
+    def snooze!
+      update!(snoozed_at: Time.now)
+    end
+
+    def snoozed?
+      snoozed_at && snoozed_at >= SNOOZE_INTERVAL.ago
+    end
+
+    def unsnooze!
+      update!(snoozed_at: nil)
+    end
   end
 end

--- a/app/models/broken_window/metric_status.rb
+++ b/app/models/broken_window/metric_status.rb
@@ -1,6 +1,6 @@
 module BrokenWindow
   class MetricStatus
-    NAMES = [:fail, :unknown, :pass]
+    NAMES = [:fail, :unknown, :pass, :snoozed]
 
     class << self
       def pass
@@ -13,6 +13,10 @@ module BrokenWindow
 
       def fail
         new(:fail)
+      end
+
+      def snoozed
+        new(:snoozed)
       end
 
       def combine(states)

--- a/app/views/broken_window/metrics/_list.html.erb
+++ b/app/views/broken_window/metrics/_list.html.erb
@@ -6,7 +6,14 @@
           <%= time_ago_in_words(metric.measurement.created_at) %> old
         </span>
       <% end %>
-      <span class="name"><%= metric.name %></span>
+
+      <span class="name">
+        <% if metric.snoozed? %>
+          <i class="fa fa-bed"></i>
+        <% end %>
+        <%= metric.name %>
+      </span>
+
       <div class="value"><%= BrokenWindow::Metric.format_value metric.value, metric.value_type %></div>
     <% end %>
   <% end %>

--- a/app/views/broken_window/metrics/show.html.erb
+++ b/app/views/broken_window/metrics/show.html.erb
@@ -1,7 +1,12 @@
 <%= link_to '', metric_up_path(@metric), class: 'back-link fa fa-level-up' %>
 
 <div class="show-metric">
-  <h1><%= @metric.name %></h1>
+  <h1>
+    <% if @metric.snoozed? %>
+      <i class="fa fa-bed"></i>
+    <% end %>
+    <%= @metric.name %>
+  </h1>
   <%- unless @metric.container? %>
     <div class="value"><%= BrokenWindow::Metric.format_value @metric.value, @metric.value_type %></div>
     <div class="required">
@@ -13,5 +18,11 @@
 <%= render partial: 'list', locals: {metrics: @metric.children} %>
 
 <div class="page-actions">
-  <%= link_to '', edit_metric_path(@metric), class: 'fa fa-pencil-square-o' %>
+  <%= link_to '', edit_metric_path(@metric), class: 'fa fa-pencil-square-o', title: 'Edit' %>
+
+  <% if @metric.snoozed? %>
+    <%= link_to '', unsnooze_metric_path(@metric), method: :post, class: 'fa fa-bell', title: "Unsnooze (snoozed at #{@metric.metric.snoozed_at})" %>
+  <% else %>
+    <%= link_to '', snooze_metric_path(@metric), method: :post, class: 'fa fa-bed', title: 'Snooze for 2 weeks' %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 BrokenWindow::Engine.routes.draw do
-  resources :metrics, path: '/'
+  resources :metrics, path: '/' do
+    post :snooze, on: :member
+    post :unsnooze, on: :member
+  end
   root to: "metrics#index"
 end

--- a/db/migrate/20170223134650_add_snoozed_at_to_metric.rb
+++ b/db/migrate/20170223134650_add_snoozed_at_to_metric.rb
@@ -1,0 +1,5 @@
+class AddSnoozedAtToMetric < ActiveRecord::Migration
+  def change
+    add_column :broken_window_metrics, :snoozed_at, :datetime
+  end
+end

--- a/spec/controllers/broken_window/metrics_controller_spec.rb
+++ b/spec/controllers/broken_window/metrics_controller_spec.rb
@@ -1,9 +1,18 @@
 require 'spec_helper'
 
 module BrokenWindow
+  class DummyCalculator
+    def initialize(*args)
+    end
+
+    def call
+      50
+    end
+  end
+
   RSpec.describe MetricsController, :type => :controller do
     routes { BrokenWindow::Engine.routes }
-    let(:metric) { Metric.create!(name: 'Percentage scraped', calculator: 'null_calculator', value_type: 'percentage', threshold: 50.0) }
+    let(:metric) { Metric.create!(name: 'Percentage scraped', calculator: 'DummyCalculator', value_type: 'percentage', threshold: 50.0, threshold_type: 'min') }
 
     describe "#show" do
       it "displays as unknown if there have never been any measurements" do

--- a/spec/controllers/broken_window/metrics_controller_spec.rb
+++ b/spec/controllers/broken_window/metrics_controller_spec.rb
@@ -19,6 +19,15 @@ module BrokenWindow
 
         expect(assigns(:status).to_s).to eq('pass')
       end
+
+      it "displays as snoonzed if the metric has been snoozed" do
+        metric.measurements.create!(value: 12.0)
+        metric.snooze!
+
+        get :show, id: metric
+
+        expect(assigns(:status).to_s).to eq('snoozed')
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a button to snooze a metric for 2 weeks. Snoozed metric
appears passed as long as it is snoozed, but with a little bed icon next to it.