### PR TITLE
[0.5] [Airbrake] [Production] undefined method `update_attributes' for #<BrokenWindow::Metric:0x00007f191d4af988> Did you mean? update_attribute

### DIFF
--- a/app/controllers/broken_window/metrics_controller.rb
+++ b/app/controllers/broken_window/metrics_controller.rb
@@ -32,7 +32,7 @@ module BrokenWindow
 
     def update
       @metric = Metric.find(params[:id])
-      if @metric.update_attributes(metric_params)
+      if @metric.update(metric_params)
         redirect_to @metric
       else
         render action: :edit


### PR DESCRIPTION
Trello card: https://trello.com/c/0WRhm3Ds

### Changes in behavior:

`update_attributes` does not work anymore on Rails 6

Background:
While trying to update threshold on a BrokenWindow metric: https://webpunch.airbrake.io/projects/153761/groups/3003211172410957444

Info that I found: https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes.html

### Post-Deploy instructions:
Update gem on WebPunch's main repo